### PR TITLE
Fix #9

### DIFF
--- a/include/sync/sync.h
+++ b/include/sync/sync.h
@@ -1,6 +1,7 @@
 #include <trace_session/connection.h>
 #include "sched_controller/rq_buffer.h"
 #include "sched_controller_session/connection.h"
+#include "mon_manager/mon_manager_connection.h"
 
 namespace Sync{
 
@@ -8,15 +9,10 @@ class Sync
 {
 	public:
 		Sync();
-		void deploy(Genode::Dataspace_capability ds_cap, int type, int core);
-		int deploy_thread(int *list);
-		Genode::Dataspace_capability init_ds(int num_rqs, int num_cores);
+		void deploy(Genode::Dataspace_capability sync_ds_cap, int type, int core);
 		
 	private:
-		void the_cycle();
-		Sched_controller::Connection sched;
-		Sched_controller::Rq_buffer<Rq_task::Rq_task> *_rqs;
-
-
+		int num_cores;
+		Mon_manager::Connection mon_manager;
 };
 }

--- a/include/sync/sync_client.h
+++ b/include/sync/sync_client.h
@@ -10,9 +10,9 @@ struct Session_client : Genode::Rpc_client<Session>
 	Session_client(Genode::Capability<Session> cap):
 		Genode::Rpc_client<Session>(cap) {}
 
-	void deploy(Genode::Dataspace_capability ds, int type, int core)
+	void deploy(Genode::Dataspace_capability sync_ds_cap, int type, int core)
 	{
-		call<Rpc_deploy>(ds_cap, type, core);
+		call<Rpc_deploy>(sync_ds_cap, type, core);
 	}
 };
 }

--- a/include/sync/sync_session.h
+++ b/include/sync/sync_session.h
@@ -13,7 +13,7 @@ namespace Sync {
 
 		static const char *service_name() { return "sync"; }
 
-		virtual void deploy(Genode::Dataspace_capability ds_cap, int type, int core) = 0;
+		virtual void deploy(Genode::Dataspace_capability sync_ds_cap, int type, int core) = 0;
 
 		GENODE_RPC(Rpc_deploy, void, deploy, Genode::Dataspace_capability, int, int);
 

--- a/src/sync/main.cc
+++ b/src/sync/main.cc
@@ -44,9 +44,9 @@ namespace Sync
 
 		public:
 
-			void deploy(Genode::Dataspace_capability ds_cap, int type, int core)
+			void deploy(Genode::Dataspace_capability sync_ds_cap, int type, int core)
 			{
-				
+				_sync->deploy(sync_ds_cap,type,core);
 			}
 
 			Session_component(Sync *sync)

--- a/src/sync/sync.cc
+++ b/src/sync/sync.cc
@@ -36,57 +36,15 @@ using namespace Genode;
 
 namespace Sync{
 	
-	Sync::Sync() {
-		Genode::Dataspace_capability ds_cap=init_ds(32,1);
-
-    sched.set_sync_ds(ds_cap);
-
-    the_cycle();
+Sync::Sync()
+{
+	//get num cores from monitor
+	num_cores=mon_manager.get_num_cores();
 }
 
-	int Sync::deploy_thread(int *list) //gmc
+	void Sync::deploy(Genode::Dataspace_capability sync_ds_cap, int type, int core)
 	{
-		int ds_size = ((1+2*list[0])*sizeof(int));
-		Genode::Ram_dataspace_capability _ds=Genode::env()->ram_session()->alloc(ds_size);
-		int *newlist = Genode::env()->rm_session()->attach(_ds);
-		for(int i=0;i<(1+2*list[0]);i++)
-		{
-			newlist[i]=list[i];
-		}
-		Genode::env()->cpu_session()->deploy_queue(_ds);		
-		Genode::env()->ram_session()->free(_ds);
-		return 1;
-	}
-
-	Genode::Dataspace_capability Sync::init_ds(int num_rqs, int num_cores)
-	{
-		int ds_size = num_cores*(4 * sizeof(int)) + (num_rqs * sizeof(Rq_task::Rq_task));
-		Genode::Dataspace_capability _ds=Genode::env()->ram_session()->alloc(ds_size);
-		_rqs = new Sched_controller::Rq_buffer<Rq_task::Rq_task>[num_cores];
-		for (int i = 0; i < num_cores; i++) {
-			_rqs[i].init_w_shared_ds(_ds);
-		}
-		return _ds;
-	}
-
-	void Sync::the_cycle()
-	{
-		
-		    while(1){
-			int list[100];
-			int counter=1;
-			sched.are_you_ready();
-			Rq_task::Rq_task *dequeued_task;
-			while(1)
-			{
-				_rqs->deq(&dequeued_task);
-				if(dequeued_task==nullptr) break;
-				list[2*counter-1]=(*dequeued_task).task_id;
-				list[2*counter]=(*dequeued_task).prio;
-				counter++;
-			}
-			list[0]=counter-1;
-			deploy_thread(list);
-    		    }
+		Genode::printf("deploy on core %d with strategy %d\n", core, type);
+		Genode::env()->cpu_session()->deploy_queue(sync_ds_cap);		
 	}
 }


### PR DESCRIPTION
Moved any code belonging to rq buffer into AdmCtrl.
AdmCtrl now tells Synchronizer when it's time to go. Not the other way round.
Core and Type are still ignored due to create_fp_edf_thread issue.